### PR TITLE
Textarea should only resize vertically

### DIFF
--- a/stylesheets/feedback.less
+++ b/stylesheets/feedback.less
@@ -24,6 +24,10 @@
     color: @text-color;
     padding: @component-padding / 3 @component-padding / 2;
   }
+  
+  textarea {
+    resize: vertical;
+  }
 
   label {
     margin-left: @component-padding;


### PR DESCRIPTION
Keeps the textarea from being able to be expanded out of the panel window.
