### PR TITLE
Increase link colour contrast

### DIFF
--- a/stylesheets/feedback.less
+++ b/stylesheets/feedback.less
@@ -50,7 +50,7 @@
 .support-info {
   a {
     text-decoration: underline;
-    color: @text-color-subtle;
+    color: inherit;
   }
 
   ul {


### PR DESCRIPTION
It’s kind of hard to read right now:

![screen shot 2014-04-17 at 0 34 12](https://cloud.githubusercontent.com/assets/1581276/2735984/4621eacc-c667-11e3-8fb3-fdd6771a1156.png)

Hoping this helps a little. Thanks for the hard work on Atom.
