### PR TITLE
Use latest version of status bar Service API

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "consumedServices": {
     "status-bar": {
       "versions": {
-        "^0.58.0": "consumeStatusBar"
+        "^1.0.0": "consumeStatusBar"
       }
     },
     "metrics-reporter": {


### PR DESCRIPTION
This updates to use the latest version of the `status-bar` Service API :pineapple: 